### PR TITLE
Allow to replace Node data

### DIFF
--- a/graphview/src/main/java/de/blox/graphview/Graph.java
+++ b/graphview/src/main/java/de/blox/graphview/Graph.java
@@ -22,6 +22,7 @@ public class Graph {
     public void addNode(@NonNull Node node) {
         if (!this.nodes.contains(node)) {
             this.nodes.add(node);
+            node.onAddedToGraph(this);
         }
     }
 
@@ -62,6 +63,7 @@ public class Graph {
         }
 
         nodes.remove(node);
+        node.onRemovedFromGraph(this);
 
         final Iterator<Edge> iterator = edges.iterator();
         while (iterator.hasNext()) {
@@ -82,6 +84,12 @@ public class Graph {
     public void removeNodes(@NonNull Node... nodes) {
         for (int i = 0; i < nodes.length; i++) {
             removeNode(nodes[i]);
+        }
+    }
+
+    void onNodeDataReplaced(Node node) {
+        for (NodeObserver observer : observers) {
+            observer.notifyDataChanged(node);
         }
     }
 

--- a/graphview/src/main/java/de/blox/graphview/Node.java
+++ b/graphview/src/main/java/de/blox/graphview/Node.java
@@ -1,6 +1,9 @@
 package de.blox.graphview;
 
 
+import java.util.IdentityHashMap;
+import java.util.Map;
+
 /**
  *
  */
@@ -8,6 +11,7 @@ public class Node {
     private Vector pos;
     private Object data;
     private Size size;
+    private Map<Graph, Integer> graphCount = new IdentityHashMap<>();
 
     public Node(Object data) {
         this.data = data;
@@ -39,6 +43,13 @@ public class Node {
         this.pos.setY(y);
     }
 
+    public void replaceData(Object data) {
+        this.data = data;
+        for (Graph graph : graphCount.keySet()) {
+            graph.onNodeDataReplaced(this);
+        }
+    }
+
     public Object getData() {
         return data;
     }
@@ -53,6 +64,24 @@ public class Node {
 
     public int getHeight() {
         return size.getHeight();
+    }
+
+    void onAddedToGraph(Graph graph) {
+        Integer count = graphCount.get(graph);
+        if (count == null)
+            count = 1;
+        graphCount.put(graph, count + 1);
+    }
+
+    void onRemovedFromGraph(Graph graph) {
+        Integer count = graphCount.get(graph);
+        if (count == null)
+            throw new IllegalStateException("Node shouldn't be removed from a graph not associated with");
+        if (count == 1) {
+            graphCount.remove(graph);
+        } else {
+            graphCount.put(graph, count -1 );
+        }
     }
 
     @Override


### PR DESCRIPTION
Added a method to `Node`: `replaceData()` which also notifies all observers of the graphs the node is in.